### PR TITLE
Add simple LLM chat SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-"# Play.LLM" 
+# Play.LLM
+
+This repository contains a simple single page application for chatting with an LLM via the [OpenRouter](https://openrouter.ai) API. It demonstrates use of function calling tools implemented in separate JavaScript files.
+
+## Usage
+
+Open `index.html` in a browser. On first use you will be prompted for your OpenRouter API key, which is stored in local storage. The chat uses the `gemini-2.0-flash-exp:free` model.
+
+The application includes two example tools available to the LLM:
+
+- **Dice Roller** – roll dice using expressions like `2d6+3`.
+- **Name Generator** – generate random fantasy names.
+
+Messages support Markdown rendering.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,15 @@
+body {
+    background-color: #f8f9fa;
+}
+
+#chat {
+    white-space: pre-wrap;
+}
+
+.message.user {
+    text-align: right;
+}
+
+.message.assistant {
+    text-align: left;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Play LLM Chat</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body class="d-flex flex-column vh-100">
+    <div class="container my-3 flex-grow-1 d-flex flex-column" id="app">
+        <div id="chat" class="border rounded p-3 mb-3 flex-grow-1 overflow-auto bg-light"></div>
+        <form id="chat-form" class="d-flex">
+            <input type="text" id="user-input" class="form-control me-2" placeholder="Type your message..." autocomplete="off">
+            <button class="btn btn-primary" type="submit">Send</button>
+        </form>
+    </div>
+
+    <script type="module" src="js/main.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,96 @@
+import { diceRollerTool, roll_dice } from '../tools/diceRoller.js';
+import { nameGeneratorTool, generate_name } from '../tools/nameGenerator.js';
+
+const chatEl = document.getElementById('chat');
+const form = document.getElementById('chat-form');
+const input = document.getElementById('user-input');
+
+const tools = [diceRollerTool, nameGeneratorTool];
+const toolFunctions = {
+    roll_dice,
+    generate_name
+};
+
+let messages = [];
+
+function appendMessage(role, content) {
+    const div = document.createElement('div');
+    div.className = `message ${role} mb-2`;
+    div.innerHTML = marked.parse(content);
+    chatEl.appendChild(div);
+    chatEl.scrollTop = chatEl.scrollHeight;
+}
+
+function getApiKey() {
+    let key = localStorage.getItem('openrouter_api_key');
+    if (!key) {
+        key = prompt('Enter your OpenRouter API key');
+        if (key) {
+            localStorage.setItem('openrouter_api_key', key);
+        }
+    }
+    return key;
+}
+
+async function callLLM() {
+    const apiKey = getApiKey();
+    if (!apiKey) {
+        alert('API key required');
+        return;
+    }
+    const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+            model: 'gemini-2.0-flash-exp:free',
+            messages,
+            tools,
+            tool_choice: 'auto'
+        })
+    });
+
+    if (!res.ok) {
+        appendMessage('assistant', `Error: ${res.status}`);
+        return;
+    }
+    const data = await res.json();
+    const choice = data.choices[0];
+    const msg = choice.message;
+
+    if (choice.finish_reason === 'tool_calls') {
+        for (const call of msg.tool_calls) {
+            const func = toolFunctions[call.function.name];
+            if (func) {
+                const args = JSON.parse(call.function.arguments || '{}');
+                const result = func(args);
+                messages.push({
+                    role: 'tool',
+                    tool_call_id: call.id,
+                    name: call.function.name,
+                    content: result
+                });
+                appendMessage('tool', result);
+            }
+        }
+        await callLLM();
+        return;
+    }
+
+    if (msg.content) {
+        appendMessage('assistant', msg.content);
+    }
+    messages.push(msg);
+}
+
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const text = input.value.trim();
+    if (!text) return;
+    appendMessage('user', text);
+    messages.push({ role: 'user', content: text });
+    input.value = '';
+    await callLLM();
+});

--- a/tools/diceRoller.js
+++ b/tools/diceRoller.js
@@ -1,0 +1,39 @@
+export const diceRollerTool = {
+    type: "function",
+    function: {
+        name: "roll_dice",
+        description: "Rolls dice using notation like '1d6' or '2d20+5'",
+        parameters: {
+            type: "object",
+            properties: {
+                expression: {
+                    type: "string",
+                    description: "Dice expression"
+                }
+            },
+            required: ["expression"]
+        }
+    }
+};
+
+export function roll_dice({ expression }) {
+    const regex = /^(\d*)d(\d+)([+-]\d+)?$/i;
+    const match = expression.match(regex);
+    if (!match) {
+        return `Invalid dice expression: ${expression}`;
+    }
+    const count = parseInt(match[1] || '1', 10);
+    const sides = parseInt(match[2], 10);
+    const modifier = match[3] ? parseInt(match[3], 10) : 0;
+
+    const rolls = [];
+    for (let i = 0; i < count; i++) {
+        rolls.push(Math.floor(Math.random() * sides) + 1);
+    }
+    const sum = rolls.reduce((a, b) => a + b, 0) + modifier;
+    let details = rolls.join(', ');
+    if (modifier) {
+        details += modifier > 0 ? ` + ${modifier}` : ` - ${Math.abs(modifier)}`;
+    }
+    return `Rolled ${expression}: [${details}] = ${sum}`;
+}

--- a/tools/nameGenerator.js
+++ b/tools/nameGenerator.js
@@ -1,0 +1,33 @@
+const names = [
+    "Aria", "Brax", "Calen", "Dara", "Eldric",
+    "Fira", "Galen", "Hara", "Ilan", "Jora",
+    "Korin", "Lira", "Mira", "Neran", "Orin",
+    "Prax", "Quin", "Risa", "Sorin", "Tara"
+];
+
+export const nameGeneratorTool = {
+    type: "function",
+    function: {
+        name: "generate_name",
+        description: "Generates random fantasy names",
+        parameters: {
+            type: "object",
+            properties: {
+                count: {
+                    type: "integer",
+                    description: "Number of names to generate",
+                    default: 1
+                }
+            }
+        }
+    }
+};
+
+export function generate_name({ count = 1 }) {
+    const result = [];
+    for (let i = 0; i < count; i++) {
+        const index = Math.floor(Math.random() * names.length);
+        result.push(names[index]);
+    }
+    return result.join(', ');
+}


### PR DESCRIPTION
## Summary
- create bootstrap single page chat app
- add markdown rendering and OpenRouter API calls
- store API key in local storage
- implement function calling tools: dice roller and name generator
- document usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6878edf90e988333b5bc66b7bd25c44a