### PR TITLE
Add error handling and nodemon dev server

### DIFF
--- a/host.bat
+++ b/host.bat
@@ -1,1 +1,3 @@
-npx http-server . -o -p 9999
+@echo off
+npx nodemon --watch . --ext js,html,css --exec "npx http-server . -o -p 9999"
+

--- a/js/main.js
+++ b/js/main.js
@@ -57,6 +57,10 @@ async function callLLM() {
         return;
     }
     const data = await res.json();
+    if (data.error) {
+        appendMessage('assistant', `Error: ${data.error.message || data.error}`);
+        return;
+    }
     const choice = data.choices[0];
     const msg = choice.message;
 


### PR DESCRIPTION
## Summary
- reload the server on file changes using nodemon in **host.bat**
- report API errors in the chat UI instead of failing silently

## Testing
- `npx nodemon --version`

------
https://chatgpt.com/codex/tasks/task_b_6878f7878e18833386b5b85c42885fe3