### PR TITLE
Fix tool call message ordering

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -80,6 +80,8 @@ async function callLLM() {
     const choice = data.choices[0];
     const msg = choice.message;
 
+    messages.push(msg);
+
     if (msg.tool_calls) {
         for (const call of msg.tool_calls) {
             const func = toolFunctions[call.function.name];
@@ -101,7 +103,6 @@ async function callLLM() {
     if (msg.content) {
         appendMessage('assistant', msg.content);
     }
-    messages.push(msg);
 }
 
 form.addEventListener('submit', async (e) => {


### PR DESCRIPTION
## Summary
- keep the assistant message that triggers tool calls in the chat history

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6879fd207b3c8333955bef0357d51e6a