### PR TITLE
Fix layout so chat area scrolls independently

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,11 +1,31 @@
+html, body {
+    height: 100%;
+}
+
 body {
     background-color: #f8f9fa;
+}
+
+#app {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
 }
 
 #chat {
     white-space: pre-wrap;
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
+    overflow-y: auto;
+}
+
+#chat-form {
+    position: sticky;
+    bottom: 0;
+    background-color: #fff;
+    padding-top: 0.5rem;
 }
 
 .message {


### PR DESCRIPTION
## Summary
- make the chat container fill available space
- allow the chat messages area to scroll
- keep the input form fixed to the bottom of the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687a0014da04833396632bfc778ba2e8