### PR TITLE
Add skill check tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This repository contains a simple single page application for chatting with an L
 
 Open `index.html` in a browser. On first use you will be prompted for your Azure OpenAI API key and resource name, which are stored in local storage. A dropdown allows selecting the deployment to use. The default deployment is `4o` and you can also choose `o3-mini`.
 
-The application includes two example tools available to the LLM:
+The application includes several example tools available to the LLM:
 
 - **Dice Roller** – roll dice using expressions like `2d6+3`.
 - **Name Generator** – generate random fantasy names.
+- **Skill Check** – roll 2d12 plus a skill bonus to beat a difficulty.
 
 Messages support Markdown rendering.
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 import { diceRollerTool, roll_dice } from '../tools/diceRoller.js';
 import { nameGeneratorTool, generate_name } from '../tools/nameGenerator.js';
+import { skillCheckTool, skill_check } from '../tools/skillCheck.js';
 
 const chatEl = document.getElementById('chat');
 const form = document.getElementById('chat-form');
@@ -8,12 +9,14 @@ const modelSelect = document.getElementById('model-select');
 
 const tools = [
     { type: 'function', function: diceRollerTool },
-    { type: 'function', function: nameGeneratorTool }
+    { type: 'function', function: nameGeneratorTool },
+    { type: 'function', function: skillCheckTool }
 ];
 
 const toolFunctions = {
     roll_dice,
-    generate_name
+    generate_name,
+    skill_check
 };
 
 let messages = [];

--- a/tools/skillCheck.js
+++ b/tools/skillCheck.js
@@ -1,0 +1,26 @@
+export const skillCheckTool = {
+    name: "skill_check",
+    description: "Performs a skill check by rolling 2d12 and adding the player's skill level to beat a difficulty.",
+    parameters: {
+        type: "object",
+        properties: {
+            difficulty: {
+                type: "integer",
+                description: "Target number to beat"
+            },
+            skill: {
+                type: "integer",
+                description: "Player's skill bonus"
+            }
+        },
+        required: ["difficulty", "skill"]
+    }
+};
+
+export function skill_check({ difficulty, skill }) {
+    const roll1 = Math.floor(Math.random() * 12) + 1;
+    const roll2 = Math.floor(Math.random() * 12) + 1;
+    const total = roll1 + roll2 + skill;
+    const success = total >= difficulty;
+    return `Rolled 2d12 (${roll1} + ${roll2}) + ${skill} = ${total}. ${success ? 'Success' : 'Failure'} against difficulty ${difficulty}.`;
+}


### PR DESCRIPTION
## Summary
- create `skillCheck` tool for rolling 2d12 plus skill vs difficulty
- register the new tool in the chat app
- document the new tool in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687a0a3102d08333bc84d4f906ee81da