### PR TITLE
Refine Character Manager item handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The application includes several example tools available to the LLM:
 - **Dice Roller** – roll dice using expressions like `2d6+3`.
 - **Name Generator** – generate random fantasy names.
 - **Skill Check** – roll 2d12 plus a skill bonus to beat a difficulty.
+- **Character Manager** – create, retrieve and modify RPG characters stored in local storage.
 
 Messages support Markdown rendering.
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,14 @@
 import { diceRollerTool, roll_dice } from '../tools/diceRoller.js';
 import { nameGeneratorTool, generate_name } from '../tools/nameGenerator.js';
 import { skillCheckTool, skill_check } from '../tools/skillCheck.js';
+import {
+    createCharacterTool,
+    getCharacterTool,
+    modifyCharacterTool,
+    create_character,
+    get_character,
+    modify_character
+} from '../tools/characterManager.js';
 
 const chatEl = document.getElementById('chat');
 const form = document.getElementById('chat-form');
@@ -10,13 +18,19 @@ const modelSelect = document.getElementById('model-select');
 const tools = [
     { type: 'function', function: diceRollerTool },
     { type: 'function', function: nameGeneratorTool },
-    { type: 'function', function: skillCheckTool }
+    { type: 'function', function: skillCheckTool },
+    { type: 'function', function: createCharacterTool },
+    { type: 'function', function: getCharacterTool },
+    { type: 'function', function: modifyCharacterTool }
 ];
 
 const toolFunctions = {
     roll_dice,
     generate_name,
-    skill_check
+    skill_check,
+    create_character,
+    get_character,
+    modify_character
 };
 
 let messages = [];

--- a/tools/characterManager.js
+++ b/tools/characterManager.js
@@ -1,0 +1,192 @@
+// Tool to manage RPG characters and monsters using local storage
+
+function loadCharacters() {
+    const json = localStorage.getItem('rpg_characters');
+    if (!json) return {};
+    try {
+        return JSON.parse(json);
+    } catch {
+        return {};
+    }
+}
+
+function saveCharacters(chars) {
+    localStorage.setItem('rpg_characters', JSON.stringify(chars));
+}
+
+export const createCharacterTool = {
+    name: 'create_character',
+    description: 'Creates a character or monster with all attributes',
+    parameters: {
+        type: 'object',
+        properties: {
+            name: { type: 'string', description: 'Character name' },
+            description: { type: 'string', description: 'Short description' },
+            stats: {
+                type: 'object',
+                description: 'Ability scores between -20 and 20',
+                properties: {
+                    strength: { type: 'integer' },
+                    dexterity: { type: 'integer' },
+                    cleverness: { type: 'integer' },
+                    quickness: { type: 'integer' },
+                    constitution: { type: 'integer' },
+                    magic_ability: { type: 'integer' },
+                    intuition: { type: 'integer' },
+                    believe: { type: 'integer' },
+                    luck: { type: 'integer' },
+                    perception: { type: 'integer' },
+                    natural_physical_resistance: { type: 'integer' },
+                    natural_magical_resistance: { type: 'integer' },
+                    influence: { type: 'integer' }
+                }
+            },
+            max_physical_hp: { type: 'integer' },
+            current_physical_hp: { type: 'integer' },
+            max_mental_hp: { type: 'integer' },
+            current_mental_hp: { type: 'integer' },
+            aspects: {
+                type: 'array',
+                description: 'Situation aspects',
+                items: {
+                    type: 'object',
+                    properties: {
+                        name: { type: 'string', description: 'Unique name' },
+                        full_name: { type: 'string', description: 'Full description' }
+                    },
+                    required: ['name', 'full_name']
+                }
+            },
+            gear: {
+                type: 'array',
+                description: 'Important gear or attributes',
+                items: {
+                    type: 'object',
+                    properties: {
+                        name: { type: 'string', description: 'Unique name' },
+                        full_name: { type: 'string', description: 'Full description' }
+                    },
+                    required: ['name', 'full_name']
+                }
+            }
+        },
+        required: ['name']
+    }
+};
+
+export function create_character(args) {
+    const chars = loadCharacters();
+    const name = args.name;
+    chars[name] = { ...args };
+    saveCharacters(chars);
+    return `Character ${name} saved.`;
+}
+
+export const getCharacterTool = {
+    name: 'get_character',
+    description: 'Retrieves a character by name',
+    parameters: {
+        type: 'object',
+        properties: {
+            name: { type: 'string', description: 'Character name' }
+        },
+        required: ['name']
+    }
+};
+
+export function get_character({ name }) {
+    const chars = loadCharacters();
+    const char = chars[name];
+    if (!char) return `Character ${name} not found.`;
+    return JSON.stringify(char);
+}
+
+export const modifyCharacterTool = {
+    name: 'modify_character',
+    description: 'Modifies fields of a character by name',
+    parameters: {
+        type: 'object',
+        properties: {
+            name: { type: 'string', description: 'Character to modify' },
+            description: { type: 'string', description: 'New description', nullable: true },
+            stats: {
+                type: 'object',
+                description: 'Ability scores to set',
+                additionalProperties: { type: 'integer' }
+            },
+            current_physical_hp: { type: 'integer', nullable: true },
+            max_physical_hp: { type: 'integer', nullable: true },
+            current_mental_hp: { type: 'integer', nullable: true },
+            max_mental_hp: { type: 'integer', nullable: true },
+            add_aspects: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        name: { type: 'string', description: 'Unique name' },
+                        full_name: { type: 'string', description: 'Full description' }
+                    },
+                    required: ['name', 'full_name']
+                }
+            },
+            remove_aspects: {
+                type: 'array',
+                items: { type: 'string' }
+            },
+            add_gear: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        name: { type: 'string', description: 'Unique name' },
+                        full_name: { type: 'string', description: 'Full description' }
+                    },
+                    required: ['name', 'full_name']
+                }
+            },
+            remove_gear: {
+                type: 'array',
+                items: { type: 'string' }
+            }
+        },
+        required: ['name']
+    }
+};
+
+export function modify_character(args) {
+    const chars = loadCharacters();
+    const char = chars[args.name];
+    if (!char) return `Character ${args.name} not found.`;
+    if (args.description !== undefined) char.description = args.description;
+    if (args.stats) {
+        char.stats = { ...char.stats, ...args.stats };
+    }
+    ['current_physical_hp','max_physical_hp','current_mental_hp','max_mental_hp'].forEach(k => {
+        if (args[k] !== undefined) char[k] = args[k];
+    });
+    if (args.add_aspects) {
+        char.aspects = char.aspects || [];
+        for (const a of args.add_aspects) {
+            if (!char.aspects.some(x => x.name === a.name)) {
+                char.aspects.push(a);
+            }
+        }
+    }
+    if (args.remove_aspects && char.aspects) {
+        char.aspects = char.aspects.filter(a => !args.remove_aspects.includes(a.name));
+    }
+    if (args.add_gear) {
+        char.gear = char.gear || [];
+        for (const g of args.add_gear) {
+            if (!char.gear.some(x => x.name === g.name)) {
+                char.gear.push(g);
+            }
+        }
+    }
+    if (args.remove_gear && char.gear) {
+        char.gear = char.gear.filter(g => !args.remove_gear.includes(g.name));
+    }
+    saveCharacters(chars);
+    return `Character ${args.name} updated.`;
+}
+


### PR DESCRIPTION
## Summary
- adjust gear and aspect parameters to include unique names
- add de-dup logic when adding aspects and gear

## Testing
- `node --check js/main.js && node --check tools/characterManager.js`


------
https://chatgpt.com/codex/tasks/task_b_687dfe3185d083339f447ddc545e8ecd