### PR TITLE
Add display_stats tool

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -51,6 +51,12 @@ body {
     font-style: italic;
 }
 
+.message.stats {
+    align-self: flex-start;
+    background-color: #d1e7dd;
+    border: 1px solid #badbcc;
+}
+
 .message > :last-child {
     margin-bottom: 0;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,7 @@ import {
     get_character,
     modify_character
 } from '../tools/characterManager.js';
+import { displayStatsTool, display_stats } from '../tools/displayStats.js';
 
 const chatEl = document.getElementById('chat');
 const form = document.getElementById('chat-form');
@@ -22,7 +23,8 @@ const tools = [
     { type: 'function', function: skillCheckTool },
     { type: 'function', function: createCharacterTool },
     { type: 'function', function: getCharacterTool },
-    { type: 'function', function: modifyCharacterTool }
+    { type: 'function', function: modifyCharacterTool },
+    { type: 'function', function: displayStatsTool }
 ];
 
 const toolFunctions = {
@@ -31,7 +33,8 @@ const toolFunctions = {
     skill_check,
     create_character,
     get_character,
-    modify_character
+    modify_character,
+    display_stats
 };
 
 let messages = [];
@@ -110,7 +113,8 @@ async function callLLM() {
                     tool_call_id: call.id,
                     content: result
                 });
-                appendMessage('function', result);
+                const role = call.function.name === 'display_stats' ? 'stats' : 'function';
+                appendMessage(role, result);
             }
         }
         await callLLM();

--- a/tools/displayStats.js
+++ b/tools/displayStats.js
@@ -1,0 +1,56 @@
+export const displayStatsTool = {
+    name: 'display_stats',
+    description: 'Displays the stats of a character or monster in a formatted block',
+    parameters: {
+        type: 'object',
+        properties: {
+            name: { type: 'string', description: 'Character name' }
+        },
+        required: ['name']
+    }
+};
+
+function loadCharacters() {
+    const json = localStorage.getItem('rpg_characters');
+    if (!json) return {};
+    try {
+        return JSON.parse(json);
+    } catch {
+        return {};
+    }
+}
+
+export function display_stats({ name }) {
+    const chars = loadCharacters();
+    const char = chars[name];
+    if (!char) return `Character ${name} not found.`;
+
+    let md = `**${char.name}**`;
+    if (char.description) {
+        md += `\n_${char.description}_`;
+    }
+    md += '\n\n| Stat | Value |\n|---|---|\n';
+    if (char.stats) {
+        for (const [k, v] of Object.entries(char.stats)) {
+            const label = k.replace(/_/g, ' ');
+            md += `| ${label} | ${v} |\n`;
+        }
+    }
+    md += `\n**Physical HP:** ${char.current_physical_hp}/${char.max_physical_hp}`;
+    md += `\n**Mental HP:** ${char.current_mental_hp}/${char.max_mental_hp}`;
+
+    if (char.aspects && char.aspects.length) {
+        md += '\n\n**Aspects**:\n';
+        for (const a of char.aspects) {
+            md += `- **${a.name}**: ${a.full_name}\n`;
+        }
+    }
+    if (char.gear && char.gear.length) {
+        md += '\n\n**Gear**:\n';
+        for (const g of char.gear) {
+            md += `- **${g.name}**: ${g.full_name}\n`;
+        }
+    }
+
+    return md.trim();
+}


### PR DESCRIPTION
## Summary
- add a new tool `display_stats` to show character or monster stats
- style chat bubbles for stats
- register the new tool with the chat UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687e24a41cd883338f24d74349ee63f6