### PR TITLE
Add character listing tool and tool message toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The application includes several example tools available to the LLM:
 - **Name Generator** – generate random fantasy names.
 - **Skill Check** – roll 2d12 plus a skill bonus to beat a difficulty.
 - **Character Manager** – create, retrieve and modify RPG characters stored in local storage.
+- **List Characters** – view existing characters filtered by text.
 
 Messages support Markdown rendering.
 

--- a/index.html
+++ b/index.html
@@ -10,10 +10,14 @@
 <body class="d-flex flex-column vh-100">
     <div class="container my-3 flex-grow-1 d-flex flex-column" id="app">
         <div id="chat" class="border rounded p-3 mb-3 flex-grow-1 overflow-auto bg-light"></div>
-        <form id="chat-form" class="d-flex">
+        <form id="chat-form" class="d-flex align-items-center">
             <input type="text" id="user-input" class="form-control me-2" placeholder="Type your message..." autocomplete="off">
             <button class="btn btn-primary me-2" type="submit">Send</button>
-            <button id="clear-data" class="btn btn-danger" type="button">Clear Data</button>
+            <button id="clear-data" class="btn btn-danger me-2" type="button">Clear Data</button>
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="show-tools">
+                <label class="form-check-label" for="show-tools">Show tool messages</label>
+            </div>
         </form>
     </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -5,9 +5,11 @@ import {
     createCharacterTool,
     getCharacterTool,
     modifyCharacterTool,
+    listCharactersTool,
     create_character,
     get_character,
-    modify_character
+    modify_character,
+    list_characters
 } from '../tools/characterManager.js';
 import { displayStatsTool, display_stats } from '../tools/displayStats.js';
 
@@ -15,6 +17,7 @@ const chatEl = document.getElementById('chat');
 const form = document.getElementById('chat-form');
 const input = document.getElementById('user-input');
 const clearBtn = document.getElementById('clear-data');
+const toolToggle = document.getElementById('show-tools');
 const deployment = 'MA01ChatGPT-gpt-4-32k';
 
 const tools = [
@@ -24,6 +27,7 @@ const tools = [
     { type: 'function', function: createCharacterTool },
     { type: 'function', function: getCharacterTool },
     { type: 'function', function: modifyCharacterTool },
+    { type: 'function', function: listCharactersTool },
     { type: 'function', function: displayStatsTool }
 ];
 
@@ -34,16 +38,28 @@ const toolFunctions = {
     create_character,
     get_character,
     modify_character,
+    list_characters,
     display_stats
 };
 
 let messages = [];
+let showTools = false;
+
+toolToggle.addEventListener('change', () => {
+    showTools = toolToggle.checked;
+    document.querySelectorAll('.message.function, .message.stats').forEach(el => {
+        el.style.display = showTools ? '' : 'none';
+    });
+});
 
 function appendMessage(role, content) {
     const div = document.createElement('div');
     div.className = `message ${role} mb-2`;
     div.innerHTML = marked.parse(content);
     chatEl.appendChild(div);
+    if ((role === 'function' || role === 'stats') && !showTools) {
+        div.style.display = 'none';
+    }
     chatEl.scrollTop = chatEl.scrollHeight;
 }
 

--- a/tools/displayStats.js
+++ b/tools/displayStats.js
@@ -22,7 +22,7 @@ function loadCharacters() {
 
 export function display_stats({ name }) {
     const chars = loadCharacters();
-    const char = chars[name];
+    const char = chars[name.toLowerCase()];
     if (!char) return `Character ${name} not found.`;
 
     let md = `**${char.name}**`;


### PR DESCRIPTION
## Summary
- add defaults for stats and HP in `characterManager`
- treat character names case-insensitively
- add `list_characters` tool for listing stored characters
- allow hiding tool output via checkbox in the UI

## Testing
- `npx --yes eslint js tools` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_687e3d215a1883339eb1eca834be24a8