### PR TITLE
Add damage check tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The application includes several example tools available to the LLM:
 - **Dice Roller** – roll dice using expressions like `2d6+3`.
 - **Name Generator** – generate random fantasy names.
 - **Skill Check** – roll 2d12 plus a skill bonus to beat a difficulty.
+- **Damage Check** – perform a skill check and roll damage dice on success.
 - **Character Manager** – create, retrieve and modify RPG characters stored in local storage.
 
 Messages support Markdown rendering.

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 import { diceRollerTool, roll_dice } from '../tools/diceRoller.js';
 import { nameGeneratorTool, generate_name } from '../tools/nameGenerator.js';
-import { skillCheckTool, skill_check } from '../tools/skillCheck.js';
+import { skillCheckTool, skill_check, damageCheckTool, damage_check } from '../tools/skillCheck.js';
 import {
     createCharacterTool,
     getCharacterTool,
@@ -21,6 +21,7 @@ const tools = [
     { type: 'function', function: diceRollerTool },
     { type: 'function', function: nameGeneratorTool },
     { type: 'function', function: skillCheckTool },
+    { type: 'function', function: damageCheckTool },
     { type: 'function', function: createCharacterTool },
     { type: 'function', function: getCharacterTool },
     { type: 'function', function: modifyCharacterTool },
@@ -31,6 +32,7 @@ const toolFunctions = {
     roll_dice,
     generate_name,
     skill_check,
+    damage_check,
     create_character,
     get_character,
     modify_character,

--- a/tools/skillCheck.js
+++ b/tools/skillCheck.js
@@ -1,3 +1,5 @@
+import { roll_dice } from './diceRoller.js';
+
 export const skillCheckTool = {
     name: "skill_check",
     description: "Performs a skill check by rolling 2d12 and adding the player's skill level to beat a difficulty.",
@@ -23,4 +25,39 @@ export function skill_check({ difficulty, skill }) {
     const total = roll1 + roll2 + skill;
     const success = total >= difficulty;
     return `Rolled 2d12 (${roll1} + ${roll2}) + ${skill} = ${total}. ${success ? 'Success' : 'Failure'} against difficulty ${difficulty}.`;
+}
+
+export const damageCheckTool = {
+    name: "damage_check",
+    description: "Performs a skill check and, on success, rolls damage using a dice expression.",
+    parameters: {
+        type: "object",
+        properties: {
+            difficulty: {
+                type: "integer",
+                description: "Target number to beat"
+            },
+            skill: {
+                type: "integer",
+                description: "Player's skill bonus"
+            },
+            damage: {
+                type: "string",
+                description: "Dice expression for damage if the check succeeds"
+            }
+        },
+        required: ["difficulty", "skill", "damage"]
+    }
+};
+
+export function damage_check({ difficulty, skill, damage }) {
+    const roll1 = Math.floor(Math.random() * 12) + 1;
+    const roll2 = Math.floor(Math.random() * 12) + 1;
+    const total = roll1 + roll2 + skill;
+    const success = total >= difficulty;
+    let result = `Rolled 2d12 (${roll1} + ${roll2}) + ${skill} = ${total}. ${success ? 'Success' : 'Failure'} against difficulty ${difficulty}.`;
+    if (success) {
+        result += ' ' + roll_dice({ expression: damage });
+    }
+    return result;
 }


### PR DESCRIPTION
## Summary
- support skill-based damage checks
- register the new `damage_check` tool in the chat app
- document the damage check tool in the README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687e3d8372f08333844959e1c22e2b8c