### PR TITLE
Add sidebar character management

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,6 +28,19 @@ body {
     padding-top: 0.5rem;
 }
 
+#character-list {
+    overflow-y: auto;
+}
+
+.character-entry {
+    position: relative;
+}
+.character-entry button.delete-character {
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+
 .message {
     padding: 0.5rem 0.75rem;
     border-radius: 0.5rem;

--- a/index.html
+++ b/index.html
@@ -8,17 +8,25 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body class="d-flex flex-column vh-100">
-    <div class="container my-3 flex-grow-1 d-flex flex-column" id="app">
-        <div id="chat" class="border rounded p-3 mb-3 flex-grow-1 overflow-auto bg-light"></div>
-        <form id="chat-form" class="d-flex align-items-center">
-            <input type="text" id="user-input" class="form-control me-2" placeholder="Type your message..." autocomplete="off">
-            <button class="btn btn-primary me-2" type="submit">Send</button>
-            <button id="clear-data" class="btn btn-danger me-2" type="button">Clear Data</button>
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="show-tools">
-                <label class="form-check-label" for="show-tools">Show tool messages</label>
+    <div class="container-fluid my-3 flex-grow-1" id="app">
+        <div class="row h-100">
+            <div class="col-md-8 d-flex flex-column h-100">
+                <div id="chat" class="border rounded p-3 mb-3 flex-grow-1 overflow-auto bg-light"></div>
+                <form id="chat-form" class="d-flex align-items-center">
+                    <input type="text" id="user-input" class="form-control me-2" placeholder="Type your message..." autocomplete="off">
+                    <button class="btn btn-primary me-2" type="submit">Send</button>
+                    <button id="clear-data" class="btn btn-danger me-2" type="button">Clear Data</button>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="show-tools">
+                        <label class="form-check-label" for="show-tools">Show tool messages</label>
+                    </div>
+                </form>
             </div>
-        </form>
+            <div class="col-md-4 d-flex flex-column h-100">
+                <h5>Characters</h5>
+                <div id="character-list" class="border rounded p-2 flex-grow-1 overflow-auto bg-light"></div>
+            </div>
+        </div>
     </div>
 
     <script type="module" src="js/main.js"></script>


### PR DESCRIPTION
## Summary
- display stored characters in a sidebar
- update character list when tools modify characters
- skip showing character stats in chat bubbles
- allow removing characters via sidebar delete buttons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687e62c0021883339436ed0a0f97a418