### PR TITLE
Improve character display styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -34,11 +34,19 @@ body {
 
 .character-entry {
     position: relative;
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+    background-color: #fff;
+    padding: 0.5rem 0.75rem;
 }
 .character-entry button.delete-character {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 0.25rem;
+    right: 0.25rem;
+}
+
+.character-entry .stats-table {
+    font-size: 0.875rem;
 }
 
 .message {

--- a/tools/displayStats.js
+++ b/tools/displayStats.js
@@ -25,32 +25,45 @@ export function display_stats({ name }) {
     const char = chars[name.toLowerCase()];
     if (!char) return `Character ${name} not found.`;
 
-    let md = `**${char.name}**`;
+    const abbr = {
+        strength: 'STR',
+        dexterity: 'DEX',
+        cleverness: 'CLV',
+        quickness: 'QCK',
+        constitution: 'CON',
+        magic_ability: 'MAG',
+        intuition: 'INT',
+        believe: 'BLV',
+        luck: 'LCK',
+        perception: 'PER',
+        natural_physical_resistance: 'NPR',
+        natural_magical_resistance: 'NMR',
+        influence: 'INF'
+    };
+
+    let html = `<strong>${char.name}</strong>`;
     if (char.description) {
-        md += `\n_${char.description}_`;
+        html += `<div class="text-muted small">${char.description}</div>`;
     }
-    md += '\n\n| Stat | Value |\n|---|---|\n';
+    html += '<table class="table table-sm stats-table mb-1"><tbody>';
     if (char.stats) {
         for (const [k, v] of Object.entries(char.stats)) {
             const label = k.replace(/_/g, ' ');
-            md += `| ${label} | ${v} |\n`;
+            const short = abbr[k] || label;
+            html += `<tr><th class="py-1 px-2"><abbr title="${label}">${short}</abbr></th><td class="py-1 px-2 text-end">${v}</td></tr>`;
         }
     }
-    md += `\n**Physical HP:** ${char.current_physical_hp}/${char.max_physical_hp}`;
-    md += `\n**Mental HP:** ${char.current_mental_hp}/${char.max_mental_hp}`;
+    html += '</tbody></table>';
+    html += `<div class="small mb-1">HP <abbr title="Physical">P</abbr>: ${char.current_physical_hp}/${char.max_physical_hp} | HP <abbr title="Mental">M</abbr>: ${char.current_mental_hp}/${char.max_mental_hp}</div>`;
 
     if (char.aspects && char.aspects.length) {
-        md += '\n\n**Aspects**:\n';
-        for (const a of char.aspects) {
-            md += `- **${a.name}**: ${a.full_name}\n`;
-        }
+        const list = char.aspects.map(a => `<abbr title="${a.full_name}">${a.name}</abbr>`).join(', ');
+        html += `<div class="small"><strong>Aspects:</strong> ${list}</div>`;
     }
     if (char.gear && char.gear.length) {
-        md += '\n\n**Gear**:\n';
-        for (const g of char.gear) {
-            md += `- **${g.name}**: ${g.full_name}\n`;
-        }
+        const list = char.gear.map(g => `<abbr title="${g.full_name}">${g.name}</abbr>`).join(', ');
+        html += `<div class="small"><strong>Gear:</strong> ${list}</div>`;
     }
 
-    return md.trim();
+    return html.trim();
 }


### PR DESCRIPTION
## Summary
- add compact card styling for character entries
- abbreviate stat names with tooltips
- output HTML for display_stats for a slimmer layout

## Testing
- `node --check tools/displayStats.js`

------
https://chatgpt.com/codex/tasks/task_b_687f953c91f883338d4d9e3dd44dc8b2