### PR TITLE
Add usedSkill parameter to skill and damage checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The application includes several example tools available to the LLM:
 
 - **Dice Roller** – roll dice using expressions like `2d6+3` or combined sets such as `2d6+1d4`.
 - **Name Generator** – generate random fantasy names.
-- **Skill Check** – roll 2d12 plus a skill bonus to beat a difficulty.
-- **Damage Check** – perform a skill check and roll damage dice on success.
+- **Skill Check** – roll 2d12 plus a skill bonus to beat a difficulty. Include the skill name and a reason for that difficulty.
+- **Damage Check** – perform a skill check and roll damage dice on success. Also requires the skill name and a reason for that difficulty.
 - **Character Manager** – create, retrieve and modify RPG characters stored in local storage.
 - **List Characters** – view existing characters filtered by text.
 

--- a/tools/skillCheck.js
+++ b/tools/skillCheck.js
@@ -14,21 +14,25 @@ export const skillCheckTool = {
                 type: "integer",
                 description: "Player's skill bonus"
             },
+            usedSkill: {
+                type: "string",
+                description: "Which skill provides the bonus",
+            },
             difficultyReason: {
                 type: "string",
                 description: "Reason for choosing this difficulty"
             }
         },
-        required: ["difficulty", "skill", "difficultyReason"]
+        required: ["difficulty", "skill", "usedSkill", "difficultyReason"]
     }
 };
 
-export function skill_check({ difficulty, skill, difficultyReason }) {
+export function skill_check({ difficulty, skill, usedSkill, difficultyReason }) {
     const roll1 = Math.floor(Math.random() * 12) + 1;
     const roll2 = Math.floor(Math.random() * 12) + 1;
     const total = roll1 + roll2 + skill;
     const success = total >= difficulty;
-    return `Rolled 2d12 (${roll1} + ${roll2}) + ${skill} = ${total}. ${success ? 'Success' : 'Failure'} against difficulty ${difficulty}. Reason: ${difficultyReason}`;
+    return `Rolled 2d12 (${roll1} + ${roll2}) + ${skill} = ${total}. ${success ? 'Success' : 'Failure'} against difficulty ${difficulty}. Skill used: ${usedSkill}. Reason: ${difficultyReason}`;
 }
 
 export const damageCheckTool = {
@@ -45,6 +49,10 @@ export const damageCheckTool = {
                 type: "integer",
                 description: "Player's skill bonus"
             },
+            usedSkill: {
+                type: "string",
+                description: "Which skill provides the bonus",
+            },
             difficultyReason: {
                 type: "string",
                 description: "Reason for choosing this difficulty"
@@ -54,16 +62,16 @@ export const damageCheckTool = {
                 description: "Dice expression for damage if the check succeeds"
             }
         },
-        required: ["difficulty", "skill", "damage", "difficultyReason"]
+        required: ["difficulty", "skill", "usedSkill", "damage", "difficultyReason"]
     }
 };
 
-export function damage_check({ difficulty, skill, damage, difficultyReason }) {
+export function damage_check({ difficulty, skill, usedSkill, damage, difficultyReason }) {
     const roll1 = Math.floor(Math.random() * 12) + 1;
     const roll2 = Math.floor(Math.random() * 12) + 1;
     const total = roll1 + roll2 + skill;
     const success = total >= difficulty;
-    let result = `Rolled 2d12 (${roll1} + ${roll2}) + ${skill} = ${total}. ${success ? 'Success' : 'Failure'} against difficulty ${difficulty}. Reason: ${difficultyReason}`;
+    let result = `Rolled 2d12 (${roll1} + ${roll2}) + ${skill} = ${total}. ${success ? 'Success' : 'Failure'} against difficulty ${difficulty}. Skill used: ${usedSkill}. Reason: ${difficultyReason}`;
     if (success) {
         result += ' ' + roll_dice({ expression: damage });
     }


### PR DESCRIPTION
## Summary
- require `usedSkill` string for both skill and damage checks
- include the used skill in result messages
- document new requirement in README

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_b_688084e69f0c8333b8a8b7d8451ee738